### PR TITLE
Graph width fix

### DIFF
--- a/app/scripts/results.coffee
+++ b/app/scripts/results.coffee
@@ -1661,6 +1661,8 @@ class view.GraphResults extends BaseResults
                 padding :
                     top : 0.1
                     right : 0.01
+            width = $(".tab-pane").width()
+            graph.setSize({width: width})
             graph.render()
             window._graph = @graph = graph
 
@@ -1670,7 +1672,10 @@ class view.GraphResults extends BaseResults
 
             $(window).on "resize", _.throttle(() =>
                 if @$result.is(":visible")
+                    width = $(".tab-pane").width()
                     graph.setSize()
+                    @preview.configure({width: width})
+                    @preview.render()
                     graph.render()
             , 200)
 


### PR DESCRIPTION
Quick&easy fix for the graph width issue.
Query the tab-pane width via JQuery on graph creation and window resize and set width accordingly