### PR TITLE
fix extended list template bug

### DIFF
--- a/app/scripts/directives.js
+++ b/app/scripts/directives.js
@@ -413,7 +413,7 @@ korpApp.directive("tabSpinner", () => ({
 }))
 
 korpApp.directive("extendedList", () => ({
-    templateUrl: require("../views/extendedlist.html"),
+    template: require("../views/extendedlist.html"),
     scope: {
         cqp: "=",
         lang: "=",


### PR DESCRIPTION
I was setting up korp inside a Docker container and ran into this bug along the way. The extended search is broken because the `templateUrl` key isn't actually set to a URL. Instead it is set to the _content_ of the template itself, which it then erroneously tries to resolve as a URL resulting in a broken extended search tab and a big red error in the JavaScript console.