### PR TITLE
Translate map attribute selection list heading

### DIFF
--- a/app/index.pug
+++ b/app/index.pug
@@ -79,7 +79,7 @@ html
                             | {{'show_map' | loc:lang}}
                             span.caret()
                           div(uib-dropdown-menu)
-                            h3.map-settings-title() Välj attribut
+                            h3.map-settings-title() {{'select_attribute' | loc:lang}}
                             ul(ng-if="mapAttributes.length != 0")
                               li(ng-repeat="attr in mapAttributes", ng-class="attr.selected ? 'selected':''", ng-click="mapToggleSelected($index, $event)")
                                 span(class="checked") ✔

--- a/app/translations/locale-en.json
+++ b/app/translations/locale-en.json
@@ -340,6 +340,7 @@
     "no_geo_info": "No location data available",
     "map_cluster": "Cluster",
     "no_row_selected_map": "Choose at least one row to show the map",
+    "select_attribute": "Select attribute",
 
     "global_filter": "Filter",
     "add_filter": "Add filter",

--- a/app/translations/locale-sv.json
+++ b/app/translations/locale-sv.json
@@ -337,6 +337,7 @@
     "no_geo_info": "Platsinformation ej tillgänglig",
     "map_cluster": "Sammanställ",
     "no_row_selected_map": "Välj minst en rad för att visa kartan",
+    "select_attribute": "Välj attribut",
 
     "global_filter": "Filter",
     "add_filter": "Lägg till filter",


### PR DESCRIPTION
Translate the heading of the map attribute selection list according to the UI language. Previously, it was “Välj attribut” even when the UI language was English.

I was hesitating if the English translation should be “Select attribute” or “Choose attribute” and if it should have the article “an” or not. I chose “Select attribute” but please change that if you find some other translation better or more suitable.