### PR TITLE
Fix #181: Statistics table CQPs for values with variants

### DIFF
--- a/app/config/statistics_config.js
+++ b/app/config/statistics_config.js
@@ -34,7 +34,7 @@ let reduceCqp = function(type, tokens, ignoreCase) {
 
                 var variants = []
                 _.map(tokens, function(val) {
-                    parts = val.split(":")
+                    const parts = val.split(":")
                     if (variants.length == 0) {
                         for (var idx = 0; idx < parts.length - 1; idx++) variants.push([])
                     }


### PR DESCRIPTION
Add a missing variable declaration to `reduceCqp` in `statistics_config.js`, handling sets of values with variant suffixes, to fix #181.

Previously, example KWIC, trend diagram and map did not open for such values.