### PR TITLE
Statistics table: Regex escape all attribute values in CQP expressions

### DIFF
--- a/app/config/statistics_config.js
+++ b/app/config/statistics_config.js
@@ -18,8 +18,11 @@ let getCqp = function(hitValues, ignoreCase) {
 let reduceCqp = function(type, tokens, ignoreCase) {
     let attrs = settings.corpusListing.getCurrentAttributes()
     if (attrs[type] && attrs[type].stats_cqp) {
+        // A stats_cqp function should call regescape for the value as
+        // appropriate
         return attrs[type].stats_cqp(tokens, ignoreCase)
     }
+    tokens = _.map(tokens, val => regescape(val))
     switch (type) {
         case "saldo":
         case "prefix":
@@ -51,7 +54,7 @@ let reduceCqp = function(type, tokens, ignoreCase) {
             }
             return type + " contains '" + res + "'"
         case "word":
-            let s = 'word="' + regescape(tokens[0]) + '"'
+            let s = 'word="' + tokens[0] + '"'
             if (ignoreCase) s = s + " %c"
             return s
         case "pos":
@@ -65,7 +68,7 @@ let reduceCqp = function(type, tokens, ignoreCase) {
             if (attrs[type]) {
                 // word attributes
                 const op = attrs[type]["type"] === "set" ? " contains " : "="
-                return $.format('%s%s"%s"', [type, op, regescape(tokens[0])])
+                return $.format('%s%s"%s"', [type, op, tokens[0]])
             } else {
                 // structural attributes
                 return $.format('_.%s="%s"', [type, tokens[0]])


### PR DESCRIPTION
Call `regescape` to escape all regular expression meta-characters in the attribute values in the CQP expressions generated for the statistics table row labels. Previously, the values of only `word` and positional attributes not explicitly listed were escaped.

This makes the statistics example KWIC, trend diagram and map work with all attribute values containing regular expression meta-characters. Previously, the result was empty or otherwise incorrect for such values (except for `word` and unlisted positional attributes). The following cases work now even when the attribute value has meta-characters:

- `saldo`, `prefix`, `suffix`, `lex`, `lemma` or `sense`: https://spraakbanken.gu.se/korp/#?cqp=%5B%5D&corpus=sweachum&search_tab=2&stats_reduce=lemma&search=cqp%7C%5Blemma%20contains%20%22.*%5B*%3F%2B%5D.*%22%5D&result_tab=2
- Same as above with multiple variant suffixes: https://spraakbanken.gu.se/korp/#?cqp=%5B%5D&search_tab=2&result_tab=2&corpus=flashback-kultur&stats_reduce=lemma&search=cqp%7C%5Blemma%20contains%20%22.*%5B*%3F%2B%5D.*:.*%22%5D
- `pos`, `deprel` or `msd`: https://spraakbanken.gu.se/korp/#?cqp=%5B%5D&search_tab=2&corpus=sweachum&stats_reduce=msd&search=cqp%7C%5Bmsd%20%3D%20%22.*%5B*%3F%2B%5D.*%22%5D&result_tab=2
- Structural attributes: https://spraakbanken.gu.se/korp/#?cqp=%5B%5D&search_tab=2&result_tab=2&corpus=romi&stats_reduce=text_title&search=cqp%7C%5B_.text_title%20%3D%20%22.*%5B*%3F%2B%5D.*%22%5D

`regescape` is called for all token attribute values after testing for a `stats_cqp` function, so that the call need not be added to each reference to an attribute value in `getCqp`. However, you’ll need to call `regescape` from a `stats_cqp` function if appropriate, as I think you might wish to pass the raw value to a `stats_cqp`. As far as I can see, that shouldn’t break anything, but I don’t know if you had a reason not to escape the attribute values in some cases.