### PR TITLE
Sidebar: Add `sidebarInfoUrl` and remove Språkbanken-specific handling of `msd`

### DIFF
--- a/app/scripts/components/sidebar.js
+++ b/app/scripts/components/sidebar.js
@@ -285,6 +285,16 @@ export const sidebarComponent = {
                         return output.append($compile(template)(scope))
                     }
 
+                    // If attrs.sidebarInfoUrl, add an info symbol
+                    // linking to the value of the property (URL)
+                    let info_link = ""
+                    if (attrs.sidebarInfoUrl) {
+                        info_link =
+                            `<a href='${attrs.sidebarInfoUrl}' target='_blank'>
+                                 <span class='sidebar_info ui-icon ui-icon-info'></span>
+                             </a>`
+                    }
+
                     output.data("attrs", attrs)
                     if (value === "|" || value === "" || value === null) {
                         output.append(
@@ -294,6 +304,8 @@ export const sidebarComponent = {
                     }
 
                     if (attrs.type === "set") {
+                        // For sets, info link after attribute label
+                        output.append(info_link)
                         pattern = attrs.pattern || '<span data-key="<%= key %>"><%= val %></span>'
                         ul = $("<ul>")
                         const getStringVal = (str) =>
@@ -355,7 +367,7 @@ export const sidebarComponent = {
                     }
 
                     if (attrs.type === "url") {
-                        return output.append(
+                        output.append(
                             `<a href='${str_value}' class='exturl sidebar_url' target='_blank'>${decodeURI(
                                 str_value
                             )}</a>`
@@ -370,7 +382,7 @@ export const sidebarComponent = {
                             </span>\
                         `)
                     } else if (attrs.pattern) {
-                        return output.append(
+                        output.append(
                             _.template(attrs.pattern)({
                                 key,
                                 val: str_value,
@@ -379,8 +391,11 @@ export const sidebarComponent = {
                             })
                         )
                     } else {
-                        return output.append(`<span>${str_value || ""}</span>`)
+                        output.append(`<span>${str_value || ""}</span>`)
                     }
+
+                    // For non-sets, info link after the value
+                    return output.append(info_link)
                 },
 
                 applyEllipse() {

--- a/app/scripts/components/sidebar.js
+++ b/app/scripts/components/sidebar.js
@@ -372,15 +372,6 @@ export const sidebarComponent = {
                                 str_value
                             )}</a>`
                         )
-                    } else if (key === "msd") {
-                        // msdTags = require '../markup/msdtags.html'
-                        const msdTags = "markup/msdtags.html"
-                        return output.append(`<span class='msd_sidebar'>${str_value}</span>
-                                <a href='${msdTags}' target='_blank'>
-                                    <span class='sidebar_info ui-icon ui-icon-info'></span>
-                                </a>
-                            </span>\
-                        `)
                     } else if (attrs.pattern) {
                         output.append(
                             _.template(attrs.pattern)({

--- a/doc/frontend_devel.md
+++ b/doc/frontend_devel.md
@@ -329,6 +329,7 @@ The config file contains the corpora declaration, wherein the available corpora 
     * `stats_cqp`: See [Custom statistics functions](#custom-statistics-functions).  
     * `isStructAttr`: `boolean`. If `true` the attribute will be treated as a structural attribute in all sense except it will be included in the `show` query parameter instead of `show_struct` for KWIC requests. Useful for structural attributes that extend to smaller portions of the text, such as name tagging.
     * `groupBy`; `string`. Should be either `group_by` or `group_by_struct`. Should only be needed for attributes with `isStructAttr: true`. Those attributes are by default sent as `group_by_struct` in the statistics, but can be overriden here.
+    * `sidebarInfoUrl`: `string` (URL). If defined and non-empty, add an info symbol ⓘ for the attribute in the sidebar, linking to the given URL. This can be used to link to an explanation page for morphosyntactic tags, for example.
 
 * `structAttributes`: refers to higher level metadata attributes. Examples include author, publishing year, URL etc. Structural attributes support the same settings as the word attributes.
 


### PR DESCRIPTION
This pull request incorporates two related changes:

1. **Add support for attribute configuration property `sidebarInfoUrl`** that adds to an attribute in the sidebar an info symbol ⓘ linking to the URL specified by the property. The info symbol is after the colon following the attribute label for set-valued attributes and after the value for other attributes.

   It would probably be possible to make do without `sidebarInfoUrl` by having an appropriate `pattern`, but I thought it would be nice to have a more general feature that could be used to easily add an info link to any attribute.

2. **Remove special, Språkbanken-specific handling of attributes named `msd`** that added an info symbol linking to a page listing the Swedish msd tags and styled the value with class `msd_sidebar`.

   The previous behaviour for `msd` can be achieved by adding the appropriate `sidebarInfoUrl` and `pattern` properties to its configuration; see pull request spraakbanken/korp-frontend-sb#7 in Språkbanken’s Korp configuration repository.

   Previously, the info link to the Swedish msd tags was added to all attributes named `msd`, including those in the Faroese corpus and the non-Swedish parts of parallel corpora, whose msd tagsets are different from that of Swedish.
