### PR TITLE
Fix #203: Regex escape location value for map KWIC CQP query

### DIFF
--- a/app/scripts/map_controllers.js
+++ b/app/scripts/map_controllers.js
@@ -106,9 +106,10 @@ korpApp.directive("mapCtrl", ($timeout, searches) => ({
                 end: 24,
                 ajaxParams: {
                     cqp: queryData.searchCqp,
-                    cqp2: `[_.${queryData.label} contains '${[point.name, point.countryCode, point.lat, point.lng].join(
+                    cqp2: `[_.${queryData.label} contains "${regescape(
+                               [point.name, point.countryCode, point.lat, point.lng].join(
                         ";"
-                    )}']{${numberOfTokens}}`,
+                    ))}"]{${numberOfTokens}}`,
                     cqp3: queryData.subCqp,
                     corpus: cl.stringifySelected(),
                     show_struct: _.keys(cl.getStructAttrs()),


### PR DESCRIPTION
Call `regescape` for the location (point) value in the map KWIC CQP query in the map controller, so that the example KWIC appears correctly for place names containing regular expression metacharacters, such as parentheses. This fixes #203.

I also changed the simple quotes in the CQP query to double quotes for the sake of consistency. (A modification of ours to the backend expected double quotes, but I fixed it to recognize single quotes, too.)