### PR TITLE
Fix #205: Show different locations with the same name on the map

### DIFF
--- a/app/scripts/map_controllers.js
+++ b/app/scripts/map_controllers.js
@@ -76,8 +76,13 @@ korpApp.directive("mapCtrl", ($timeout, searches) => ({
         var getMarkers = function (label, cqp, corpora, within, res, idx) {
             const markers = {}
 
-            for (let point of res.points) {
-                const id = point.name.replace(/-/g, "") + idx
+            for (let [pointIdx, point] of res.points.entries()) {
+                // Include point index in the key, so that multiple
+                // places with the same name but different coordinates
+                // each get their own markers
+                const id = [point.name.replace(/-/g, ""),
+                            pointIdx.toString(),
+                            idx].join(":")
                 markers[id] = {
                     lat: point.lat,
                     lng: point.lng,


### PR DESCRIPTION
Show locations with the same name but with different coordinates on the map. If multiple places have the same name but different coordinates, generate markers for each of them by including the point index in the marker key. (Previously, the last one overrode the preceding ones.) This fixes #205.

I modified function `getMarkers` in the map controller to return an object with property names composed of the location name, the index of the location (point) in the location data and the marker index, separated by a colon.

I’m wondering if the previous format of the property names (a location name suffixed with a marker index) is expected somewhere else in the code, but I didn’t find any such code nor did I notice any unwanted side-effects, at least with the little testing I did.