### PR TITLE
Fix #202: Set initial values for a structService attribute

### DIFF
--- a/app/scripts/extended.js
+++ b/app/scripts/extended.js
@@ -75,6 +75,9 @@ const selectController = (autocomplete) => [
             )
         }
 
+        // Load values initially
+        reloadValues()
+
         $scope.$watch("orObj.op", (newVal, oldVal) => {
             $scope.inputOnly = !["=", "!=", "contains", "not contains"].includes($scope.orObj.op)
             if (newVal !== oldVal) {


### PR DESCRIPTION
Get the initial values for an attribute with a `structService` extended controller by calling `reloadValues` also immediately after defining it in `selectController` and not only when the chosen corpora are changed. 

Previously, an attribute value selection list using a `structService` extended controller appeared empty before page reload.

This fixes #202, which was apparently introduced in commit 86669666 fixing #187. I tested the test cases in #187 with this fix and they appeared to work correctly.