### PR TITLE
Fix #214: Use HTTP POST in backend requests with a corpus parameter

### DIFF
--- a/app/scripts/model.js
+++ b/app/scripts/model.js
@@ -51,6 +51,18 @@ class BaseProxy {
         this.total = null
     }
 
+    // Return a URL with baseUrl base and data encoded as URL parameters
+    makeUrlWithParams(baseUrl, data) {
+        return (baseUrl +
+                "?" +
+                _.toPairs(data)
+                .map(function ([key, val]) {
+                    val = encodeURIComponent(val)
+                    return key + "=" + val
+                })
+                .join("&"))
+    }
+
     abort() {
         if (this.pendingRequests.length) {
             return _.invokeMap(this.pendingRequests, "abort")
@@ -221,15 +233,7 @@ model.KWICProxy = class KWICProxy extends BaseProxy {
             beforeSend(req, settings) {
                 self.prevRequest = settings
                 self.addAuthorizationHeader(req)
-                self.prevUrl =
-                    this.url +
-                    "?" +
-                    _.toPairs(data)
-                        .map(function ([key, val]) {
-                            val = encodeURIComponent(val)
-                            return key + "=" + val
-                        })
-                        .join("&")
+                self.prevUrl = self.makeUrlWithParams(this.url, data)
             },
 
             success(data, status, jqxhr) {
@@ -262,6 +266,7 @@ model.LemgramProxy = class LemgramProxy extends BaseProxy {
         const def = $.ajax({
             url: settings.korpBackendURL + "/relations",
             data: params,
+            method: "POST",
 
             success() {
                 self.prevRequest = params
@@ -279,7 +284,7 @@ model.LemgramProxy = class LemgramProxy extends BaseProxy {
             beforeSend(req, settings) {
                 self.prevRequest = settings
                 self.addAuthorizationHeader(req)
-                self.prevUrl = this.url
+                self.prevUrl = self.makeUrlWithParams(this.url, params)
             },
         })
         this.pendingRequests.push(def)
@@ -365,11 +370,12 @@ model.StatsProxy = class StatsProxy extends BaseProxy {
         this.pendingRequests.push(
             $.ajax({
                 url: settings.korpBackendURL + "/count",
+                method: "POST",
                 data,
                 beforeSend(req, settings) {
                     self.prevRequest = settings
                     self.addAuthorizationHeader(req)
-                    self.prevUrl = this.url
+                    self.prevUrl = self.makeUrlWithParams(this.url, data)
                 },
 
                 error(jqXHR, textStatus, errorThrown) {
@@ -579,11 +585,12 @@ model.GraphProxy = class GraphProxy extends BaseProxy {
             url: settings.korpBackendURL + "/count_time",
             dataType: "json",
             data: params,
+            method: "POST",
 
             beforeSend: (req, settings) => {
                 this.prevRequest = settings
                 this.addAuthorizationHeader(req)
-                self.prevUrl = this.url
+                self.prevUrl = self.makeUrlWithParams(this.url, params)
             },
 
             progress: (data, e) => {

--- a/app/scripts/services.js
+++ b/app/scripts/services.js
@@ -99,8 +99,8 @@ korpApp.factory("backend", ($http, $q, utils, lexicons) => ({
 
         const conf = {
             url: settings.korpBackendURL + "/loglike",
-            params,
-            method: "GET",
+            data: params,
+            method: "POST",
             headers: {},
         }
 
@@ -189,8 +189,8 @@ korpApp.factory("backend", ($http, $q, utils, lexicons) => ({
 
         const conf = {
             url: settings.korpBackendURL + "/count",
-            params,
-            method: "GET",
+            data: params,
+            method: "POST",
             headers: {},
         }
 
@@ -229,8 +229,8 @@ korpApp.factory("backend", ($http, $q, utils, lexicons) => ({
 
         const conf = {
             url: settings.korpBackendURL + "/query",
-            params,
-            method: "GET",
+            data: params,
+            method: "POST",
             headers: {},
         }
 

--- a/app/scripts/struct_services.js
+++ b/app/scripts/struct_services.js
@@ -338,8 +338,8 @@ korpApp.factory("structService", ($http, $q) => ({
 
             const conf = {
                 url: settings.korpBackendURL + "/struct_values",
-                params,
-                method: "GET",
+                data: params,
+                method: "POST",
                 headers: {},
             }
 


### PR DESCRIPTION
Use the HTTP POST method for Korp backend requests with the `corpus` parameter, to avoid “URI too long” errors when a large number of corpora are selected.

This fixes #214, except for the JSON buttons that are still links containing the backend parameters in the URL, so they will not work with a large number of corpora.

Some backend requests already used HTTP POST, and I tried to convert all the rest with a `corpus` parameter. In general, I just replaced `method: "GET"` with `method: "POST"` and `params` with `data` in the AJAX options.