### PR TITLE
Use HTTP POST only if the backend URL would be too long for GET

### DIFF
--- a/app/scripts/model.js
+++ b/app/scripts/model.js
@@ -226,8 +226,7 @@ model.KWICProxy = class KWICProxy extends BaseProxy {
         this.prevParams = data
         const command = data.command || "query"
         delete data.command
-        const def = $.ajax({
-            method: "POST",
+        const def = $.ajax(util.httpConfAddMethod({
             url: settings.korpBackendURL + "/" + command,
             data,
             beforeSend(req, settings) {
@@ -245,7 +244,7 @@ model.KWICProxy = class KWICProxy extends BaseProxy {
             },
 
             progress: progressObj.progress,
-        })
+        }))
         this.pendingRequests.push(def)
         return def
     }
@@ -263,10 +262,9 @@ model.LemgramProxy = class LemgramProxy extends BaseProxy {
             max: 1000,
         }
         this.prevParams = params
-        const def = $.ajax({
+        const def = $.ajax(util.httpConfAddMethod({
             url: settings.korpBackendURL + "/relations",
             data: params,
-            method: "POST",
 
             success() {
                 self.prevRequest = params
@@ -286,7 +284,7 @@ model.LemgramProxy = class LemgramProxy extends BaseProxy {
                 self.addAuthorizationHeader(req)
                 self.prevUrl = self.makeUrlWithParams(this.url, params)
             },
-        })
+        }))
         this.pendingRequests.push(def)
         return def
     }
@@ -368,9 +366,8 @@ model.StatsProxy = class StatsProxy extends BaseProxy {
         this.prevParams = data
         const def = $.Deferred()
         this.pendingRequests.push(
-            $.ajax({
+            $.ajax(util.httpConfAddMethod({
                 url: settings.korpBackendURL + "/count",
-                method: "POST",
                 data,
                 beforeSend(req, settings) {
                     self.prevRequest = settings
@@ -403,7 +400,7 @@ model.StatsProxy = class StatsProxy extends BaseProxy {
                     model.normalizeStatsData(data)
                     statisticsService.processData(def, data, reduceVals, reduceValLabels, ignoreCase)
                 },
-            })
+            }))
         )
 
         return def.promise()
@@ -466,14 +463,13 @@ model.TimeProxy = class TimeProxy extends BaseProxy {
     makeRequest() {
         const dfd = $.Deferred()
 
-        const xhr = $.ajax({
+        const xhr = $.ajax(util.httpConfAddMethod({
             url: settings.korpBackendURL + "/timespan",
-            type: "POST",
             data: {
                 granularity: "y",
                 corpus: settings.corpusListing.stringifyAll(),
             },
-        })
+        }))
 
         xhr.done((data) => {
             if (data.ERROR) {
@@ -581,11 +577,10 @@ model.GraphProxy = class GraphProxy extends BaseProxy {
         this.prevParams = params
         const def = $.Deferred()
 
-        $.ajax({
+        $.ajax(util.httpConfAddMethod({
             url: settings.korpBackendURL + "/count_time",
             dataType: "json",
             data: params,
-            method: "POST",
 
             beforeSend: (req, settings) => {
                 this.prevRequest = settings
@@ -608,7 +603,7 @@ model.GraphProxy = class GraphProxy extends BaseProxy {
                 def.resolve(data)
                 self.cleanup()
             },
-        })
+        }))
 
         return def.promise()
     }

--- a/app/scripts/services.js
+++ b/app/scripts/services.js
@@ -97,12 +97,11 @@ korpApp.factory("backend", ($http, $q, utils, lexicons) => ({
             top,
         }
 
-        const conf = {
+        const conf = util.httpConfAddMethod({
             url: settings.korpBackendURL + "/loglike",
-            data: params,
-            method: "POST",
+            params,
             headers: {},
-        }
+        })
 
         _.extend(conf.headers, model.getAuthorizationHeader())
 
@@ -187,12 +186,11 @@ korpApp.factory("backend", ($http, $q, utils, lexicons) => ({
 
         _.extend(params, cqpSubExprs)
 
-        const conf = {
+        const conf = util.httpConfAddMethod({
             url: settings.korpBackendURL + "/count",
-            data: params,
-            method: "POST",
+            params,
             headers: {},
-        }
+        })
 
         _.extend(conf.headers, model.getAuthorizationHeader())
 
@@ -227,12 +225,11 @@ korpApp.factory("backend", ($http, $q, utils, lexicons) => ({
             end: 0,
         }
 
-        const conf = {
+        const conf = util.httpConfAddMethod({
             url: settings.korpBackendURL + "/query",
-            data: params,
-            method: "POST",
+            params,
             headers: {},
-        }
+        })
 
         _.extend(conf.headers, model.getAuthorizationHeader())
 
@@ -287,12 +284,15 @@ korpApp.factory("searches", [
 
             getInfoData() {
                 const def = $q.defer()
-                $http
-                    .post(settings.korpBackendURL + "/corpus_info", {
+                const conf = util.httpConfAddMethod({
+                    url: settings.korpBackendURL + "/corpus_info",
+                    params: {
                         corpus: _.map(settings.corpusListing.corpora, "id")
                             .map((a) => a.toUpperCase())
                             .join(","),
-                    })
+                    },
+                })
+                $http(conf)
                     .then(function (response) {
                         const { data } = response
                         for (let corpus of settings.corpusListing.corpora) {
@@ -456,13 +456,15 @@ korpApp.factory("lexicons", function ($q, $http) {
                         let lemgram = karpLemgrams.join(",")
                         const corpora = corporaIDs.join(",")
                         const headers = model.getAuthorizationHeader()
-                        headers["Content-Type"] = "application/x-www-form-urlencoded; charset=UTF-8"
-                        return $http({
-                            method: "POST",
+                        return $http(util.httpConfAddMethod({
                             url: settings.korpBackendURL + "/lemgram_count",
-                            data: `lemgram=${lemgram}&count=lemgram&corpus=${corpora}`,
+                            params: {
+                                lemgram: lemgram,
+                                count: "lemgram",
+                                corpus: corpora,
+                            },
                             headers,
-                        }).then(({ data }) => {
+                        })).then(({ data }) => {
                             delete data.time
                             const allLemgrams = []
                             for (lemgram in data) {

--- a/app/scripts/settings.js
+++ b/app/scripts/settings.js
@@ -13,4 +13,9 @@ export function setDefaultConfigValues() {
     if (!settings.groupStatistics) {
         settings.groupStatistics = []
     }
+    if (! settings.backendURLMaxLength) {
+        // The default maximum URI length for Apache is 8190 but keep
+        // some safety margin
+        settings.backendURLMaxLength = 8100
+    }
 }

--- a/app/scripts/struct_services.js
+++ b/app/scripts/struct_services.js
@@ -336,12 +336,11 @@ korpApp.factory("structService", ($http, $q) => ({
                 params.split = _.last(attributes)
             }
 
-            const conf = {
+            const conf = util.httpConfAddMethod({
                 url: settings.korpBackendURL + "/struct_values",
-                data: params,
-                method: "POST",
+                params,
                 headers: {},
-            }
+            })
 
             _.extend(conf.headers, model.getAuthorizationHeader())
 

--- a/app/scripts/util.js
+++ b/app/scripts/util.js
@@ -1046,3 +1046,32 @@ window.__.remove = function (arr, elem) {
         return arr.splice(arr.indexOf(elem), 1)
     }
 }
+
+
+// Add HTTP method to the HTTP configuration object conf for
+// jQuery.ajax or AngularJS $http call: if the result URL would be
+// longer than settings.backendURLMaxLength, use POST, otherwise GET.
+// For a $http configuration, the request parameters should be in
+// property "params" of conf (moved to "data" for POST), and for a
+// jQuery.ajax configuration, they should be in "data".
+util.httpConfAddMethod = function (conf) {
+
+    // Return the length of baseUrl with params added
+    const calcUrlLength = function (baseUrl, params) {
+        return baseUrl.length + new URLSearchParams(params).toString().length + 1
+    }
+
+    // The property to use for GET: AngularJS $http uses params for
+    // GET and data for POST, whereas jQuery.ajax uses data for both
+    const getDataProp = (conf.params != undefined ? "params" : "data")
+    const data = conf.data || conf.params
+    if (calcUrlLength(conf.url, data) > settings.backendURLMaxLength) {
+        conf.method = "POST"
+        conf.data = data
+        delete conf.params
+    } else {
+        conf.method = "GET"
+        conf[getDataProp] = data
+    }
+    return conf
+}

--- a/doc/frontend_devel.md
+++ b/doc/frontend_devel.md
@@ -603,6 +603,8 @@ __cgiScript__ - URL to Korp CGI-script
 
 __downloadCgiScript__ - URL to Korp download CGI-script
 
+__backendURLMaxLength__ - Integer. The maximum length of URL (in bytes) to be passed to the backend. If the URL would be longer, use HTTP POST method instead of GET. The default is 8100, tailored for Apache’s default maximum HTTP request line length of 8190 bytes.
+
 __wordpicture__ - Boolean. Enable word picture.
 
 __statisticsCaseInsensitiveDefault__ - Boolean. Selects case-insensitive for "compile based on" by default.


### PR DESCRIPTION
Use the HTTP POST method in Korp backend calls only if the URL would be too long for GET.

This implements #216, but #214 for the JSON buttons remains open.

The threshold for using POST can be controlled by changing the value of `settings.backendURLMaxLength`, which defaults to 8100 for the Apache default (with some safety margin). You might wish to change it if you use a custom-compiled Apache or another Web server with a larger limit. Or you can set it to 0 if you always wish to use POST.

GET is always used for the `/authenticate` endpoint, and Karp backend calls are not affected.

The implementation is based on calling a new function `util.httpConfAddMethod` in `util.js` for adding (or changing) the HTTP method to the HTTP request configuration object before passing it to `$.ajax` (jQuery) or `$http` (AngularJS). As `$.ajax` takes the query parameters in property `data` of the configuration object regardless of the HTTP method but `$http` uses `data` for POST and `params` for GET, `$http` request configuration objects need to have the parameters in `params` and `$.ajax` ones in `data` for the function to work correctly.