### PR TITLE
Fix #222: Fix JSON buttons to work in KWIC and word picture

### DIFF
--- a/app/scripts/model.js
+++ b/app/scripts/model.js
@@ -51,8 +51,19 @@ class BaseProxy {
         this.total = null
     }
 
-    // Return a URL with baseUrl base and data encoded as URL parameters
+    // Return a URL with baseUrl base and data encoded as URL parameters.
+    // If baseUrl already contains URL parameters, return it as is.
+    //
+    // Note that this function is now largely redundant: when called
+    // for GET URLs already containing URL parameters, it does
+    // nothing, whereas the GET URL returned by it for a POST URL
+    // typically results in an "URI too long" error, if
+    // settings.backendURLMaxLength is configured appropriately for
+    // the Web server on which the backend runs.
     makeUrlWithParams(baseUrl, data) {
+        if (baseUrl.indexOf("?") != -1) {
+            return baseUrl
+        }
         return (baseUrl +
                 "?" +
                 _.toPairs(data)


### PR DESCRIPTION
Do not duplicate URL parameters in JSON URLs so that the JSON buttons the KWIC and word picture no longer result in backend `ValueErrors`. This fixes #222.

I implemented the fix by making `BaseProxy.makeUrlWithParams` return the URL as is if it already contains URL parameters, as it does for GET requests.

Note that function `BaseProxy.makeUrlWithParams` is now largely redundant: when called for GET requests already containing URL parameters, it does nothing, whereas the GET URL returned by it for a POST request typically result in an “URI too long” error from the Web server, if `settings.backendURLMaxLength` is configured appropriately for the Web server on which the backend runs. However, I thought that the overlong GET URL might sometimes be useful for debugging or documentation purposes, so I kept the function at least for the present. Anyway, this does _not_ make JSON buttons work for very long URLs.