### PR TITLE
Fix #201: KWIC: Select the first match after every search

### DIFF
--- a/app/scripts/results.js
+++ b/app/scripts/results.js
@@ -300,10 +300,13 @@ view.KWICResults = class KWICResults extends BaseResults {
             const useContextData = locationSearch()["in_order"] != null
             if (isReading || useContextData) {
                 $scope.setContextData(data)
-                this.selectionManager.deselect()
             } else {
                 $scope.setKwicData(data)
             }
+            // Deselect the possibly selected word, so that a word
+            // will be selected in the new result and the sidebar
+            // content will be updated
+            this.selectionManager.deselect()
         })
 
         if (currentMode === "parallel" && !isReading) {

--- a/app/scripts/results.js
+++ b/app/scripts/results.js
@@ -284,6 +284,12 @@ view.KWICResults = class KWICResults extends BaseResults {
 
     renderResult(data) {
         const resultError = super.renderResult(data)
+        // If an error occurred or the result is otherwise empty,
+        // deselect word and hide the sidebar
+        if (! this.hasData || ! data.kwic || ! data.kwic.length) {
+            this.selectionManager.deselect()
+            statemachine.send("DESELECT_WORD")
+        }
         if (resultError === false) {
             return
         }


### PR DESCRIPTION
Select the first matched word in the first hit of the KWIC result and show its information in the sidebar after every search and not only after the initial search.

Also hide the sidebar when the result is empty or an error occurred.

This fixes #201.

Previously, further searches did not select the word and the sidebar showed information for the word selected in the previous search result. If the result was empty or an error had occurred, the sidebar was left visible showing information on the previously selected word.

The main fix was simply to deselect the possibly previously selected word when rendering the result also for the KWIC view and not only for the context view (“reading mode”).