### PR TITLE
Fix #226: KWIC: Reliably switch between KWIC and context views

### DIFF
--- a/app/scripts/result_controllers.js
+++ b/app/scripts/result_controllers.js
@@ -50,7 +50,15 @@ class KwicCtrl {
 
         const readingChange = function () {
             if (s.instance && s.instance.getProxy().pendingRequests.length) {
-                return $.when(...(s.instance.getProxy().pendingRequests || [])).then(function () {
+                // If the requests passed to $.when contain rejected
+                // (aborted) requests, .then is not executed, so
+                // filter those out
+                // TODO: Remove at least rejected requests from
+                // pendingRequests somewhere
+                const nonRejectedRequests =
+                      (s.instance.getProxy().pendingRequests || []).filter(
+                          req => req.state() != "rejected")
+                return $.when(...nonRejectedRequests).then(function () {
                     return s.instance.makeRequest()
                 })
             }


### PR DESCRIPTION
Switch between the KWIC and context views even if `kwicProxy.pendingRequests` contains rejected requests, resulting from the user aborting a search and probably some other conditions in at least the simple search. Previously, such rejected requests inhibited switching the view.

This fixes #226. However, at least as I see it, this does *not* fix the root cause of rejected requests remaining in `kwicProxy.pendingRequests`.

I don’t know if it would be better to test the state of a `jqXHR` request with `.state()` (from `Deferred`) or `.readyState` or `.status`, compatible with `XMLHttpRequest` or if it makes any difference; I chose `req.state() != "rejected"`.