### PR TITLE
`settings.js`: Use `_.defaults` to reduce repetitive code

### DIFF
--- a/app/scripts/settings.js
+++ b/app/scripts/settings.js
@@ -4,35 +4,34 @@
  * function to set default values if parameters have been left out of config.js
  */
 export function setDefaultConfigValues() {
-    if (!settings["hits_per_page_values"]) {
-        settings["hits_per_page_values"] = [25, 50, 75, 100]
-    }
-    if (!settings["hits_per_page_default"]) {
-        settings["hits_per_page_default"] = settings["hits_per_page_values"][0]
-    }
-    if (!settings["group_statistics"]) {
-        settings["group_statistics"] = []
-    }
-    if (!settings.backendURLMaxLength) {
+
+    // Default values for some settings properties
+    const settingsDefaults = {
+        hits_per_page_values: [25, 50, 75, 100],
+        group_statistics: [],
         // The default maximum URI length for Apache is 8190 but keep
         // some safety margin
-        settings.backendURLMaxLength = 8100
-    }
-    if (!settings["default_language"]) {
-        settings["default_language"] = "swe"
-    }
-    // codes for translation ISO-639-1 to 639-2
-    if (!settings.isoLanguages) {
-        settings.isoLanguages = {
+        backendURLMaxLength: 8100,
+        default_language: "swe",
+        // codes for translation ISO-639-1 to 639-2
+        isoLanguages: {
             en: "eng",
             sv: "swe",
             fi: "fin",
             da: "dan",
             no: "nor",
-        }
+        },
+        cqp_prio: ["deprel", "pos", "msd", "suffix", "prefix", "grundform", "lemgram", "saldo", "word"],
     }
 
-    if (!settings["cqp_prio"]) {
-        settings["cqp_prio"] = ["deprel", "pos", "msd", "suffix", "prefix", "grundform", "lemgram", "saldo", "word"]
+    // Assign default values to settings properties if undefined
+    _.defaults(settings, settingsDefaults)
+
+    // Default values depending on other settings values, possibly
+    // assigned a default value above
+    const settingsDefaultsDep = {
+        hits_per_page_default: settings.hits_per_page_values[0],
     }
+
+    _.defaults(settings, settingsDefaultsDep)
 }


### PR DESCRIPTION
Use an object containing the default values and [`_.defaults`](https://lodash.com/docs/4.17.15#defaults) to assign defaults to configuration variables in `settings.js`, to simplify code and reduce repetition.

This means that instead of having for each value code like

```javascript
    if (!settings["some_setting"]) {
        settings["some_setting"] = default_value
    }
```

you can just add the property to the defaults object:

```javascript
        some_setting: default_value,
```
        
This is a tiny improvement and completely invisible to the user, but I find the latter version nicer, less verbose and less repetitive. Even though the file currently contains only a few such settings and the change doesn’t make much difference, I think the benefits will become the clearer the more such default values are added.

A small complication comes when a default value depends on the value of another setting, such as `hits_per_page_default` getting the first value in `hits_per_page_values`, whose value might be the default or come from the configuration. I solved this by having a second `_.defaults` call for such cases.

(I have made a few modifications to Korp with their own configuration settings that should have default values, and I found it a bit boring to type the `if` statements, so I have my own interests in this change. I intend to contribute most of those modifications once they are in a stable enough state and once I have rebased them on the then-current `dev` branch.)