### PR TITLE
Fix #257: Cite Korp: Update links and add a missing space

### DIFF
--- a/app/translations/locale-eng.json
+++ b/app/translations/locale-eng.json
@@ -38,7 +38,7 @@
     "about_short": "About Korp",
     "about_body": "Korp is the concordance search tool of Språkbanken (The Swedish Language Bank). For more information, comments or suggestions, <a href='mailto:sb-info@svenska.gu.se'>contact us</a>.",
     "about_cite_header": "Cite Korp",
-    "about_cite": "Lars Borin, Markus Forsberg and Johan Roxendal. 2012. <a target='_blank' href='https://spraakbanken.gu.se/eng/publikationer/korp-%E2%80%93-corpus-infrastructure-sprakbanken'>Korp – the corpus infrastructure of Språkbanken</a>Proceedings of LREC 2012. Istanbul: ELRA, pages 474–478.<br><a href='https://spraakbanken.gu.se/publication/1822/bibtex'><img src='https://spraakbanken.gu.se/sites/spraakbanken.gu.se/modules/custom/gup_publications/images/bibtex.png' alt='BibTeX'></a>",
+    "about_cite": "Lars Borin, Markus Forsberg and Johan Roxendal. 2012. <a target='_blank' href='https://gup.ub.gu.se/publication/156080?lang=en'>Korp – the corpus infrastructure of Språkbanken</a>. Proceedings of LREC 2012. Istanbul: ELRA, pages 474–478.<br><a href='https://spraakbanken.gu.se/en/research/publications/bibtex/156080'><img src='https://spraakbanken.gu.se/modules/custom/sb_publications/assets/bibtex.png' alt='BibTeX'></a>",
     "about_man": "Project Managers",
     "about_dev": "Developers",
     "about_dev_additional": "Annotation team",

--- a/app/translations/locale-swe.json
+++ b/app/translations/locale-swe.json
@@ -38,7 +38,7 @@
     "about_short": "Om Korp",
     "about_body": "Korp är Språkbankens konkordansverktyg. För mer information, kommentarer eller förslag, kontakta <a href='mailto:sb-info@svenska.gu.se'>Språkbanken</a>.",
     "about_cite_header": "Referera till Korp",
-    "about_cite": "Lars Borin, Markus Forsberg and Johan Roxendal. 2012. <a target='_blank' href='https://spraakbanken.gu.se/eng/publikationer/korp-%E2%80%93-corpus-infrastructure-sprakbanken'>Korp – the corpus infrastructure of Språkbanken</a>. Proceedings of LREC 2012. Istanbul: ELRA, pages 474–478.<br><a href='https://spraakbanken.gu.se/publication/1822/bibtex'><img src='https://spraakbanken.gu.se/sites/spraakbanken.gu.se/modules/custom/gup_publications/images/bibtex.png' alt='BibTeX'></a>",
+    "about_cite": "Lars Borin, Markus Forsberg and Johan Roxendal. 2012. <a target='_blank' href='https://gup.ub.gu.se/publication/156080?lang=sv'>Korp – the corpus infrastructure of Språkbanken</a>. Proceedings of LREC 2012. Istanbul: ELRA, pages 474–478.<br><a href='https://spraakbanken.gu.se/forskning/publikationer/bibtex/156080'><img src='https://spraakbanken.gu.se/modules/custom/sb_publications/assets/bibtex.png' alt='BibTeX'></a>",
     "about_man": "Projektledning",
     "about_dev": "Utvecklare",
     "about_dev_additional": "Annoteringsgruppen",


### PR DESCRIPTION
Update the links to the [LREC 2012 Korp paper](https://gup.ub.gu.se/publication/156080?lang=en), [its BibTeX record](https://spraakbanken.gu.se/en/research/publications/bibtex/156080) and  [the BibTeX logo](https://spraakbanken.gu.se/modules/custom/sb_publications/assets/bibtex.png) in the “Cite Korp” modal to working ones. This fixes #257.

Also add a missing full stop and space after the publication title in the English text.