### PR TITLE
Cite Korp: Localize “and” between logo author names

### DIFF
--- a/app/markup/about.html
+++ b/app/markup/about.html
@@ -50,7 +50,7 @@
 
         </ul>
 
-        <span>{{'about_logo' | loc:lang}}</span> <span>Dick Claésson och Johan Roxendal</span>.
+        <span>{{'about_logo' | loc:lang}}</span> <span>Dick Claésson {{'and' | loc:lang}} Johan Roxendal</span>.
 
     </div>
 </div>


### PR DESCRIPTION
Localize the “and” between the names of the logo authors in the Cite Korp modal. Previously, it was always “och”.

(This was such a tiny fix that I decided not to create a corresponding issue.)