### PR TITLE
Sidebar: support for hiding labels in e.g. link attributes

### DIFF
--- a/app/scripts/components/sidebar.js
+++ b/app/scripts/components/sidebar.js
@@ -227,7 +227,7 @@ export const sidebarComponent = {
                 renderItem(type, key, value, attrs, wordData, sentenceData, tokens) {
                     let output, pattern, ul
                     let val, inner, li, address
-                    if (attrs.label) {
+                    if (attrs.label && ! attrs["sidebar_hide_label"]) {
                         output = $(`<p><span>${locObj(attrs.label, $ctrl.lang)}</span>: </p>`)
                     } else {
                         output = $("<p></p>")

--- a/doc/frontend_devel.md
+++ b/doc/frontend_devel.md
@@ -519,6 +519,9 @@ parameters for attributes.
 - **sidebar_component**: See [Customizing sidebar](#customizing-sidebar).
 - **sidebar_info_url**: `string` (URL). If defined and non-empty, add an info symbol ⓘ for the attribute in the
   sidebar, linking to the given URL. This can be used to link to an explanation page for morphosyntactic tags, for example.
+- **sidebar_hide_label**: `boolean`. If `true`, do not show the localized attribute label and the colon following it in the
+  sidebar, only the attribute value. This can be used, for example, if the `pattern` for the attribute includes the label but
+  the label should be shown in the attribute lists of the extended search or statistics.
 - **stats_cqp**: See [Custom statistics functions](#custom-statistics-functions).  
 - **stats_stringify**: See [Custom statistics functions](#custom-statistics-functions).
 - **translation**: An object containing translations of possible values of the attribute, in this format:


### PR DESCRIPTION
This parameter allows showing links in the sidebar without having to show the corresponding attribute label.
We tested that this does not break the default SB configuration.