### PR TITLE
Support overriding logos in configuration (resolves #325)

### DIFF
--- a/app/scripts/components/app-header.ts
+++ b/app/scripts/components/app-header.ts
@@ -29,6 +29,31 @@ type HeaderController = IController & {
     visible: Config["modes"]
 }
 
+// Allow overriding logos with site-specific ones specified in the
+// configuration
+
+const korpLogoHtml: string =
+    settings["logo"]?.["korp"] ??
+    html`<img ng-if="$root.lang == 'swe'" src="${korpLogo}" height="300" width="300" />
+        <img ng-if="$root.lang != 'swe'" src="${korpLogoEn}" height="300" width="300" />`
+
+const orgLogoHtml: string =
+    settings["logo"]?.["organization"] ??
+    html`<a
+            class="hidden min-[1150px]:flex h-20 shrink flex-col justify-end"
+            href="https://spraakbanken.gu.se/"
+            target="_blank"
+        >
+            <img ng-if="$root.lang == 'swe'" src="${sbxLogo}" />
+            <img ng-if="$root.lang != 'swe'" src="${sbxLogoEn}" />
+        </a>
+
+        <a class="hidden xl:block shrink-0 h-32 -mt-2" href="https://gu.se/" target="_blank">
+            <img src="${guLogo}" class="h-full" />
+        </a>`
+
+const chooserRightLogoHtml: string = settings["logo"]?.["chooser_right"] ?? ""
+
 angular.module("korpApp").component("appHeader", {
     template: html`
         <div id="header">
@@ -95,10 +120,7 @@ angular.module("korpApp").component("appHeader", {
             </div>
 
             <div class="flex justify-between items-end gap-3 my-3 px-3" id="header_left">
-                <a class="shrink-0 relative ml-4 pl-0.5" ng-click="$ctrl.logoClick()">
-                    <img ng-if="$root.lang == 'swe'" src="${korpLogo}" height="300" width="300" />
-                    <img ng-if="$root.lang != 'swe'" src="${korpLogoEn}" height="300" width="300" />
-                </a>
+                <a class="shrink-0 relative ml-4 pl-0.5" ng-click="$ctrl.logoClick()"> ${korpLogoHtml} </a>
                 <div id="labs_logo">
                     <svg
                         height="60"
@@ -122,20 +144,10 @@ angular.module("korpApp").component("appHeader", {
 
                 <div class="grow min-[1150px]:hidden"></div>
                 <corpus-chooser></corpus-chooser>
+                ${chooserRightLogoHtml}
                 <div class="grow hidden min-[1150px]:block"></div>
 
-                <a
-                    class="hidden min-[1150px]:flex h-20 shrink flex-col justify-end"
-                    href="https://spraakbanken.gu.se/"
-                    target="_blank"
-                >
-                    <img ng-if="$root.lang == 'swe'" src="${sbxLogo}" />
-                    <img ng-if="$root.lang != 'swe'" src="${sbxLogoEn}" />
-                </a>
-
-                <a class="hidden xl:block shrink-0 h-32 -mt-2" href="https://gu.se/" target="_blank">
-                    <img src="${guLogo}" class="h-full" />
-                </a>
+                ${orgLogoHtml}
             </div>
         </div>
     `,

--- a/app/scripts/settings/app-settings.types.ts
+++ b/app/scripts/settings/app-settings.types.ts
@@ -47,6 +47,11 @@ export type AppSettings = {
     iso_languages: Record<string, string>
     korp_backend_url: string
     languages: Labeled[]
+    logo?: {
+        korp?: string
+        organization?: string
+        chooser_right?: string
+    }
     map_center?: { lat: number; lng: number; zoom: number }
     map_enabled?: boolean
     markup: Record<string, string>

--- a/doc/frontend_devel.md
+++ b/doc/frontend_devel.md
@@ -100,6 +100,11 @@ settings that affect the frontend.
     - value: swe
       label: Svenska
     ```
+- __logo__ - Object. Specify site-specific logos, overriding those of Språkbanken. Default: Use Språkbanken’s logos.
+  - __korp__ - String. HTML content for the Korp logo to the left of the corpus chooser.
+  - __organization__ - String. HTML content for the organization logo(s) on the top right of the Korp window.
+  - __chooser_right__ - String. HTML content for a logo to the right of the corpus chooser: Default: empty.
+  The HTML content can refer to image files in the `app/img/` directory of the configuration as `img/`_file_, and to the [plain Korp logo](../app/img/korp.svg) as `img/korp.svg`.
 
 **Others:**
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -131,6 +131,12 @@ module.exports = {
                     to: "img",
                 },
                 {
+                    // Allow referring to the Korp logo from the
+                    // configuration
+                    from: "app/img/korp.svg",
+                    to: "img",
+                },
+                {
                     from: "app/img/apple-touch-icon.png",
                     to: "img",
                 },
@@ -163,6 +169,12 @@ module.exports = {
                 {
                     from: korpConfigDir + "/translations/*",
                     to: "translations/[name].[fullhash][ext]",
+                },
+                {
+                    // Copy images in the configuration
+                    from: korpConfigDir + "/img/*",
+                    to: "img/[name][ext]",
+                    noErrorOnMissing: true,
                 },
             ],
         }),


### PR DESCRIPTION
**What**

Support overriding Språkbanken’s logos with site-specific ones specified in the configuration.

**Why**

Being able to specify site-specific logos in the configuration would be one step in making it easier for other Korp sites to customize their Korp installations with configuration only, without having to modify Korp code proper.

This would resolve #325.

**Configuration settings**

Logos are specified in `config.yml` by using the setting `logo` that can have three sub-items:
- `korp`: Korp logo to the left of the corpus chooser
- `organization`: organization logo(s) on the top right
- `chooser_right`: logo to the right of the corpus chooser (empty in Språkbanken)

The value for each of these is HTML content, typically an `img` element, possibly wrapped in an `a` element to create a link. Images in the `app/img/` subdirectory under the configuration are copied to be visible as `img/`_file_, as is the plain Korp logo `app/img/korp.svg` (without the slogan).

If `logo` or a sub-item of it is not specified, Språkbanken’s default is used for that item.

`logo` needs to be specified in `config.yml` or in mode-specific JavaScript files; it does not work if specified in a backend mode configuration.

These new configuration settings are documented in [`frontend_devel.md`](https://github.com/CSCfi/Kielipankki-korp-frontend/blob/03bdc9debe6597a1104113f5a9eae62c7e28419b/doc/frontend_devel.md?plain=1#L103-L107).

**Example**

This feature can be seen in work [here](https://www.kielipankki.fi/future/korp/), with [this configuration](https://github.com/CSCfi/Kielipankki-korp-frontend/blob/a21dfc06d8cff8d16645c4fe181cbef88fc90060/app/config.yml#L62-L75) (and the images referred to). It is a test Korp installation for Kielipankki that is currently the same as Språkbanken’s up-to-date Korp but with our configuration with the logos changed using this feature. (The main menu is also localized via another feature for which I intend to create a pull request later.)

**Implementation and other notes**

I augmented `webpack.common.js` to copy files from the `app/img/` subdirectory of the configuration to `img/` of the Webpack bundle. These files can be directly referred to from the HTML snippets as usual.

I don’t know if this approach has drawbacks compared with importing images and using them via variables as for Språkbanken’s logos.

More generally, I don’t know if this is a good way to implement site-specific logos but at least it would seem to work.

I left the HTML snippets for Språkbanken’s logos in `app/scripts/components/app-header.ts` so that they are close to the place where they originally were. Another option could be to specify them as the default values of the `logo` setting but then they would be in `app/scripts/settings/index.ts`.

Support for logos elsewhere on the Korp page (at least in the page header) could probably be added relatively easily.