### PR TITLE
feat: download Word Picture results as CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 
-## Fixed
+### Added
+
+- Download Word Picture results as CSV [#200](https://github.com/spraakbanken/korp-frontend/issues/200)
+
+### Fixed
 
 - KWIC download sometimes fails because row.structs is optional [#492](https://github.com/spraakbanken/korp-frontend/issues/492)
 - Moved morphology labels in the lemgram autocomplete

--- a/app/scripts/csv.ts
+++ b/app/scripts/csv.ts
@@ -1,0 +1,17 @@
+import CSV from "comma-separated-values/csv"
+import { downloadFile } from "./util"
+
+export type CsvType = keyof typeof CSV_TYPES
+
+export const CSV_TYPES = {
+    comma: { delimiter: ",", ext: "csv", mime: "text/csv" },
+    semi: { delimiter: ";", ext: "csv", mime: "text/csv" },
+    tab: { delimiter: "\t", ext: "tsv", mime: "text/tab-separated-values" },
+}
+
+/** Create a CSV file and trigger a download */
+export function downloadCsvFile(name: string, rows: Iterable<string[]>, type: CsvType) {
+    const { delimiter, ext, mime } = CSV_TYPES[type]
+    const csv = CSV.encode([...rows], { delimiter })
+    downloadFile(csv, `korp-${name}.${ext}`, mime)
+}

--- a/app/scripts/word-picture.ts
+++ b/app/scripts/word-picture.ts
@@ -117,5 +117,19 @@ export class WordPicture {
     }
 
     /** Get a string for the params that identify a word picture column */
-    getColumnId = (pos: string, rel: string, reverse: boolean) => `${pos}${reverse ? "+" : "-"}${rel}`
+    getColumnId = (pos: string, rel: string, reverse: boolean) => `${pos}${reverse ? "+" : "-"}${rel}`;
+
+    /** Create listing of full data, suitable for CSV export. */
+    *generateCsv(): Generator<string[]> {
+        const fields: (keyof MatchedRelation)[] = ["head", "headpos", "dep", "deppos", "rel", "depextra", "freq", "mi"]
+        // Header row
+        yield fields
+
+        // Data rows
+        for (const key of Object.keys(this.items)) {
+            for (const relation of this.items[key]) {
+                yield fields.map((field) => String(relation[field] || ""))
+            }
+        }
+    }
 }

--- a/app/translations/locale-eng.json
+++ b/app/translations/locale-eng.json
@@ -307,6 +307,10 @@
     "statstable_export": "Export",
     "statstable_gen_export": "Generate export",
 
+    "csv_comma": "Comma-separated values (CSV)",
+    "csv_semi": "Semicolon-separated values (CSV)",
+    "csv_tab": "Tab-separated values (TSV)",
+
     "util_decimalseparator": ".",
 
     "chapter": "chapter",

--- a/app/translations/locale-swe.json
+++ b/app/translations/locale-swe.json
@@ -306,6 +306,10 @@
     "statstable_export": "Exportera",
     "statstable_gen_export": "Generera export",
 
+    "csv_comma": "Kommaseparerade värden (CSV)",
+    "csv_semi": "Semikolonseparerade värden (CSV)",
+    "csv_tab": "Tabbseparerade värden (TSV)",
+
     "util_decimalseparator": ",",
 
     "chapter": "kapitel",


### PR DESCRIPTION
Fixes #200 

Example output for [corpus=vivill&search=lemgram|framtid..nn.1](https://spraakbanken.gu.se/korp/#?corpus=vivill&search=lemgram%7Cframtid%5C.%5C.nn%5C.1&result_tab=3):

head | headpos | dep | deppos | rel | depextra | freq | mi
-- | -- | -- | -- | -- | -- | -- | --
bero..vb.1 | VB | framtid..nn.1 | NN | SS |   | 5 | 33.8413483530782
upplösa..vb.1 | VB | framtid..nn.1 | NN | SS |   | 3 | 25.4418344334391

- Should POS and rel codes be translated?
- Should source corpora (without sentence ids) be included?
- Should we use head–dep like the backend, or match–other–reverse like in GUI?